### PR TITLE
[QA] #106 관리자 계정 삭제시, 관리자 리스트 리랜더링

### DIFF
--- a/src/components/common/Modal/AdminDeleteModal.js
+++ b/src/components/common/Modal/AdminDeleteModal.js
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 import ModalPortal from './ModalPortal';
 import axios from '../../../services/defaultClient';
 
-function AdminDeleteModal({ onClose, adminIdx, setErrMsg, handleErrModal }) {
+function AdminDeleteModal({ onClose, adminIdx, setErrMsg, handleErrModal, setIsDelete }) {
   const onAdminDelete = async () => {
     try {
       await axios.delete(`/admins/${adminIdx}`);
+      setIsDelete(() => true);
     } catch (err) {
       setErrMsg(err.response.data.error);
       handleErrModal();
@@ -45,6 +46,7 @@ AdminDeleteModal.propTypes = {
   adminIdx: PropTypes.number,
   setErrMsg: PropTypes.func.isRequired,
   handleErrModal: PropTypes.func.isRequired,
+  setIsDelete: PropTypes.bool.isRequired,
 };
 
 AdminDeleteModal.defaultProps = {

--- a/src/pages/admin/AdminListPage.js
+++ b/src/pages/admin/AdminListPage.js
@@ -15,7 +15,7 @@ function AdminListPage() {
   const [limit] = useState(10);
 
   const offset = (page - 1) * limit;
-
+  const [isDelete, setIsDelete] = useState(false)
   const [deleteModalOn, setDeleteModalOn] = useState(false);
   const handleDeleteModal = () => {
     setDeleteModalOn(prev => !prev);
@@ -39,8 +39,11 @@ function AdminListPage() {
   };
 
   useEffect(() => {
-    getAdminList();
-  }, [deleteModalOn]);
+    if(isDelete){
+      getAdminList();
+      setIsDelete(() => false)
+    }
+  }, [isDelete]);
 
   return (
     <>
@@ -60,6 +63,7 @@ function AdminListPage() {
           adminIdx={deleteAdminIdx}
           setErrMsg={setErrMsg}
           handleErrModal={handleErrModal}
+          setIsDelete={setIsDelete}
         />
       )}
       {errModalOn && <ConfirmModal onClose={handleErrModal} title="비밀번호 변경 실패" content={errMsg} />}


### PR DESCRIPTION
## Motivation 🤓
스트레칭 계정 삭제시, 관리자 리스트 리랜더링
<br>

## Key Changes 🔑
삭제 유무를 판단하는 `isDelete` `state` 추가
```
 useEffect(() => {
    if(isDelete){
      getAdminList();
      setIsDelete(() => false)
    }
  }, [isDelete]);
```
<br>

## To Reviewers 🙋‍♀️
close #106 