### PR TITLE
[QA] #110 스트레칭 검색시, 한글자 입력마다 흐름 끊기는 현상

### DIFF
--- a/src/pages/stretching/StretchingListPage.js
+++ b/src/pages/stretching/StretchingListPage.js
@@ -1,13 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import axios from '../../services/defaultClient';
 
-import Loading from '../../components/common/elements/Loading';
 import StretchingList from '../../components/stretching/StretchingList';
 import ConfirmModal from '../../components/common/Modal/ConfirmModal';
 
 function StretchingListPage() {
-  const [loading, setLoading] = useState(true);
-
   const [stretchings, setStretchings] = useState([]);
   const [title, setTitle] = useState('');
 
@@ -45,7 +42,6 @@ function StretchingListPage() {
   useEffect(() => {
     const getStretchingList = async () => {
       try {
-        setLoading(true);
         const res = await axios.get(
           `/stretchings?title=${title}&mainCategory=${mainBody}&subCategory=${subBody}&posture=${posture}&effect=${effect}&tool=${tool}`,
         );
@@ -56,16 +52,13 @@ function StretchingListPage() {
         setErrMsg(err.response.data.error);
         handleErrModal();
       }
-      setLoading(false);
     };
 
     getStretchingList();
     setPage(1);
   }, [title, mainBody, subBody, posture, effect, tool]);
 
-  return loading ? (
-    <Loading />
-  ) : (
+  return (
     <>
       <StretchingList
         stretchings={stretchings}


### PR DESCRIPTION
## Motivation 🤓
스트레칭 검색시, 한글자(한번의 `keyDown event`)마다 한글자 입력마다 흐름이 끊김
<br>

## Key Changes 🔑
원인: 제목이 변경될 때마다 `getStretchingList` 를 호출하는데, 해당 함수 내부에서 함수 시작과 끝에 `loading state` 변수를 `true` => `false` 로 바꿔주고 있었음.
 따라서 해당 함수 호출마다 `loading` 화면이 빠르게 나왔다가, 사라졌다 반복하여 흐름이 끊기는 것 처럼 보임.

해결 : 해당 페이지의` loading state` 변수를 제거
<br>

## To Reviewers 🙋‍♀️
.

close #110 